### PR TITLE
fix splunk log checker

### DIFF
--- a/splunk_service.go
+++ b/splunk_service.go
@@ -275,9 +275,13 @@ func validateJob(sid string, job *jobDetails) error {
 		// mainly looking for warnings caused by index failures (type=WARN), but we treat any message as a bad omen for now
 		// note that index failures still result in status=DONE
 		if len(job.Entry[0].Content.Messages) > 0 {
-			message := fmt.Sprintf("Splunk job %v has status %v with messages: %v", sid, job.Entry[0].Content.DispatchState, job.Entry[0].Content.Messages)
-			log.Printf(message)
-			return NewJobFailure(message)
+			for _, msg := range job.Entry[0].Content.Messages{
+				if msg.Type == "ERROR"{
+					message := fmt.Sprintf("Splunk job %v has status %v with messages: %v", sid, job.Entry[0].Content.DispatchState, job.Entry[0].Content.Messages)
+					log.Printf(message)
+					return NewJobFailure(message)
+				}
+			}
 		}
 
 		if job.Entry[0].Content.DispatchState == "FAILED" {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -117,7 +117,7 @@
 			"revisionTime": "2017-02-06T03:21:01Z"
 		},
 		{
-			"checksumSHA1": "uTQtOqR0ePMMcvuvAIksiIZxhqU=",
+			"checksumSHA1": "Xhsm+TevJogC8U4sG6FO+czBMps=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "7a6e5648d140666db5d920909e082ca00a87ba2c",
 			"revisionTime": "2017-02-01T04:15:14Z"


### PR DESCRIPTION
Due the recent splunk's updates some checks stoped working, with this fix we're logging just the errors, avoiding warnings and other type of messages.